### PR TITLE
Update maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: windows-latest
 
+permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 25


### PR DESCRIPTION
Added in write contents permissions. This was ChatGPT's recommendation to stop the "Update dependency graph" step from failing.